### PR TITLE
domobjectderivce conflict implementation

### DIFF
--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -89,5 +89,9 @@ fn expand_dom_object(input: syn::DeriveInput) -> quote::Tokens {
         const #dummy_const: () = { #items };
     };
 
+    if name == "Test" {
+        println!("{}", tokens);
+    }
+
     tokens
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -212,6 +212,7 @@ pub mod types {
     include!(concat!(env!("OUT_DIR"), "/build/InterfaceTypes.rs"));
 }
 
+pub mod test;
 pub mod abstractworker;
 pub mod abstractworkerglobalscope;
 pub mod activation;

--- a/components/script/dom/test.rs
+++ b/components/script/dom/test.rs
@@ -1,0 +1,51 @@
+use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
+use dom_struct::dom_struct;
+use dom::bindings::trace::JSTraceable;
+
+#[dom_struct]
+pub struct Test<TH: TypeHolderTrait + 'static> {
+	reflector_: Reflector,
+	_p: TH::ServoParser,
+	_a: i32,
+}
+
+pub trait TypeHolderTrait {
+    type ServoParser: ServoParser;
+
+}
+
+pub trait ServoParser {
+    
+}
+
+// #[allow(non_upper_case_globals)]
+// const _IMPL_DOMOBJECT_FOR_Test: () = {
+//     impl<TH: TypeHolderTrait + 'static> ::js::conversions::ToJSValConvertible for Test<TH> {
+//         #[allow(unsafe_code)]
+//         unsafe fn to_jsval(
+//             &self,
+//             cx: *mut ::js::jsapi::JSContext,
+//             rval: ::js::rust::MutableHandleValue,
+//         ) {
+//             let object = ::dom::bindings::reflector::DomObject::reflector(self).get_jsobject();
+//             object.to_jsval(cx, rval)
+//         }
+//     }
+//     impl<TH: TypeHolderTrait + 'static> ::dom::bindings::reflector::DomObject for Test<TH> {
+//         #[inline]
+//         fn reflector(&self) -> &::dom::bindings::reflector::Reflector {
+//             self.reflector_.reflector()
+//         }
+//     }
+//     impl<TH: TypeHolderTrait + 'static> ::dom::bindings::reflector::MutDomObject for Test<TH> {
+//         fn init_reflector(&mut self, obj: *mut ::js::jsapi::JSObject) {
+//             self.reflector_.init_reflector(obj);
+//         }
+//     }
+//     impl<TH: TypeHolderTrait + 'static> ShouldNotImplDomObject for ((TH), TH::ServoParser) {}
+//     impl<TH: TypeHolderTrait + 'static> ShouldNotImplDomObject for ((TH), i32) {}
+//     trait ShouldNotImplDomObject {}
+//     impl<TH: TypeHolderTrait + 'static, __T: ::dom::bindings::reflector::DomObject>
+//         ShouldNotImplDomObject for ((TH), __T)
+//     {}
+// };


### PR DESCRIPTION
Compilation errors:
```
error[E0119]: conflicting implementations of trait `dom::test::_IMPL_DOMOBJECT_FOR_Test::ShouldNotImplDomObject` for type `(_, i32)`:
  --> components/script/dom/test.rs:46:5
   |
45 |     impl<TH: TypeHolderTrait + 'static> ShouldNotImplDomObject for ((TH), TH::ServoParser) {}
   |     -------------------------------------------------------------------------------------- first implementation here
46 |     impl<TH: TypeHolderTrait + 'static> ShouldNotImplDomObject for ((TH), i32) {}
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(_, i32)`
```